### PR TITLE
Update enforcement contact email in CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at <opensource@muenchendigital.io>.
+reported to the community leaders responsible for enforcement at <opensource@muenchen.de>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
Replaced the outdated opensource@muenchendigital.io address with the new opensource@muenchen.de.